### PR TITLE
Missing comma on tickscript.join - Fixed

### DIFF
--- a/src/shared/constants/fluxFunctions.ts
+++ b/src/shared/constants/fluxFunctions.ts
@@ -7565,7 +7565,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     desc:
       'Merges two input streams into a single output stream based on specified columns with equal values and appends a new measurement name.',
     example: `tickscript.join(
-    tables: {t1: example1, t2: example2}
+    tables: {t1: example1, t2: example2},
     on: ["_time"],
     measurement: "example-measurement"
 )`,


### PR DESCRIPTION
<!-- Describe your proposed changes here. -->

Missing comma added on `tickscript.join` function.

If you `Inject` the function `tickscript.join` on the ui. You will get the next error:

```
compilation failed: error @19:6-23:2: expected comma in property list, got COLON

error @21:7-21:18: missing property key 
```

Closes #
